### PR TITLE
don't end the download stream

### DIFF
--- a/server/src/download-all.js
+++ b/server/src/download-all.js
@@ -160,7 +160,7 @@ class DownloadAll extends EventEmitter {
 
         await archive.finalize();
 
-        return res.end();
+        //return res.end();  // don't do this, this breaks downloading!
     }
 
 


### PR DESCRIPTION
Don't do res.end() on the download stream! It breaks downloads (they can be incomplete).